### PR TITLE
Use namespaced Turf packages instead of deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "polyline-normals": "^2.0.2",
     "proj4": "^2.4.0",
     "reproject": "^1.0.0",
-    "turf-meta": "^3.0.12"
+    "@turf/meta": "^3.0.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "wavefront",
     "obj"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https@github.com:perliedman/geojson2obj.git"
+  },
   "author": "Per Liedman <per@liedman.net>",
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
Simple changes to clean up the npm install and keep this package in good shape. Turf has deprecated the old package names and is namespacing now. I've also added the missing repository info that npm complained about.